### PR TITLE
Disambiguate uid_t and gid_t

### DIFF
--- a/include/CommonAPI/SomeIP/ClientId.hpp
+++ b/include/CommonAPI/SomeIP/ClientId.hpp
@@ -38,13 +38,13 @@ public:
     COMMONAPI_EXPORT size_t hashCode();
 
     COMMONAPI_EXPORT client_id_t getClientId();
-    COMMONAPI_EXPORT uid_t getUid() const;
-    COMMONAPI_EXPORT gid_t getGid() const;
+    COMMONAPI_EXPORT CommonAPI::uid_t getUid() const;
+    COMMONAPI_EXPORT CommonAPI::gid_t getGid() const;
 
 protected:
     client_id_t client_id_;
-    uid_t uid_;
-    gid_t gid_;
+    CommonAPI::uid_t uid_;
+    CommonAPI::gid_t gid_;
 };
 
 } // namespace SomeIP

--- a/src/CommonAPI/SomeIP/ClientId.cpp
+++ b/src/CommonAPI/SomeIP/ClientId.cpp
@@ -52,11 +52,11 @@ client_id_t ClientId::getClientId() {
     return client_id_;
 }
 
-uid_t ClientId::getUid() const {
+CommonAPI::uid_t ClientId::getUid() const {
     return uid_;
 }
 
-gid_t ClientId::getGid() const {
+CommonAPI::gid_t ClientId::getGid() const {
     return gid_;
 }
 


### PR DESCRIPTION
This fixes a compilation error on qcc71 when compiling against vsomeip 3.4.10